### PR TITLE
Canceling Orders, Events and Tests

### DIFF
--- a/src/main/scala/darkpool/actors/LedgerActor.scala
+++ b/src/main/scala/darkpool/actors/LedgerActor.scala
@@ -1,13 +1,13 @@
 package darkpool.actors
 
-import akka.actor.Actor
+import akka.actor.{ActorLogging, Actor}
 import darkpool.models.Trade
 
-class LedgerActor extends Actor {
+class LedgerActor extends Actor with ActorLogging {
   def recordTransaction(trade: Trade) {
     trade match {
       case Trade(buyer, seller, price, quantity) =>
-        println(s"$buyer bought $quantity from $seller for $$$price")
+        log.info(s"$buyer bought $quantity from $seller for $$$price")
     }
   }
 

--- a/src/main/scala/darkpool/actors/LedgerActor.scala
+++ b/src/main/scala/darkpool/actors/LedgerActor.scala
@@ -6,13 +6,13 @@ import darkpool.models.Trade
 class LedgerActor extends Actor with ActorLogging {
   def recordTransaction(trade: Trade) {
     trade match {
-      case Trade(buyer, seller, price, quantity) =>
+      case Trade(buyer, seller, buyOrder, sellOrder, price, quantity) =>
         log.info(s"$buyer bought $quantity from $seller for $$$price")
     }
   }
 
   override def receive: Receive = {
-    case trade @ Trade(_, _, _, _) =>
+    case trade @ Trade(_, _, _, _, _, _) =>
       recordTransaction(trade)
   }
 }

--- a/src/main/scala/darkpool/actors/MatchingEngineActor.scala
+++ b/src/main/scala/darkpool/actors/MatchingEngineActor.scala
@@ -48,4 +48,9 @@ class MatchingEngineActor(buyOrderBook: OrderBook[Buy], sellOrderBook: OrderBook
   override protected def canceledOrderCallback(order: Order) {
     context.actorSelection("/user/ledger") ! order
   }
+
+  override protected def selfTradePreventionCallback(trade: Trade) {
+    // TODO: Create a new self trade type?
+    context.actorSelection("/user/ledger") ! trade
+  }
 }

--- a/src/main/scala/darkpool/actors/MatchingEngineActor.scala
+++ b/src/main/scala/darkpool/actors/MatchingEngineActor.scala
@@ -3,20 +3,49 @@ package darkpool.actors
 import akka.actor.{Actor, ActorLogging}
 import darkpool.book.OrderBook
 import darkpool.engine.MatchingEngine
-import darkpool.engine.commands.{Snapshot, Cancel, Add}
-import darkpool.models.orders.{Buy, Sell}
+import darkpool.engine.commands.{Add, Cancel, Snapshot, _}
+import darkpool.models.Trade
+import darkpool.models.orders.{Buy, Order, Sell}
+
+import scala.util.{Success, Try, Failure}
 
 class MatchingEngineActor(buyOrderBook: OrderBook[Buy], sellOrderBook: OrderBook[Sell])
   extends MatchingEngine(buyOrderBook, sellOrderBook) with Actor with ActorLogging {
 
   override def receive: Receive = {
-    case Add(order) => acceptOrder(order)
-      log.info(s"Accepting order: $order")
+    case Add(order) => Try(acceptOrder(order)) match {
+      case Success(_) =>
+        log.info(s"Accepting order: $order")
+        sender ! OrderAdded
+      case Failure(exception) =>
+        log.info(s"Rejecting order: $order; Exception: ${exception.getMessage}")
+        sender ! OrderNotAdded
+    }
+
     case Cancel(order) => cancelOrder(order)
-      log.info(s"Canceling order: $order")
+      books(order.orderType)._1.canceledOrders.headOption match {
+        case Some(canceledOrder) if canceledOrder.id == order.id =>
+          log.info(s"Canceling order: $order")
+          sender ! OrderCanceled(canceledOrder)
+        case _ =>
+          log.info(s"Cannot cancel order: $order")
+          sender ! OrderNotCanceled
+      }
+
     case Snapshot =>
       log.info(s"Generating market snapshot")
-      context.actorSelection("/user/api") ! marketSnapshot
+      sender ! marketSnapshot
   }
 
+  override protected def tradeCallback(trade: Trade) {
+    context.actorSelection("/user/ledger") ! trade
+  }
+
+  override protected def acceptedOrderCallback(order: Order ) {
+    context.actorSelection("/user/ledger") ! order
+  }
+
+  override protected def canceledOrderCallback(order: Order) {
+    context.actorSelection("/user/ledger") ! order
+  }
 }

--- a/src/main/scala/darkpool/actors/MatchingEngineActor.scala
+++ b/src/main/scala/darkpool/actors/MatchingEngineActor.scala
@@ -1,0 +1,22 @@
+package darkpool.actors
+
+import akka.actor.{Actor, ActorLogging}
+import darkpool.book.OrderBook
+import darkpool.engine.MatchingEngine
+import darkpool.engine.commands.{Snapshot, Cancel, Add}
+import darkpool.models.orders.{Buy, Sell}
+
+class MatchingEngineActor(buyOrderBook: OrderBook[Buy], sellOrderBook: OrderBook[Sell])
+  extends MatchingEngine(buyOrderBook, sellOrderBook) with Actor with ActorLogging {
+
+  override def receive: Receive = {
+    case Add(order) => acceptOrder(order)
+      log.info(s"Accepting order: $order")
+    case Cancel(order) => cancelOrder(order)
+      log.info(s"Canceling order: $order")
+    case Snapshot =>
+      log.info(s"Generating market snapshot")
+      context.actorSelection("/user/api") ! marketSnapshot
+  }
+
+}

--- a/src/main/scala/darkpool/actors/QueryActor.scala
+++ b/src/main/scala/darkpool/actors/QueryActor.scala
@@ -1,0 +1,11 @@
+package darkpool.actors
+
+import akka.actor.{Actor, ActorLogging}
+import darkpool.engine.commands.MarketSnapshot
+
+class QueryActor extends Actor with ActorLogging {
+  override def receive: Receive = {
+    case marketSnapshot @ MarketSnapshot(_, _, _, _) =>
+      log.info(s"Received market snapshot: $marketSnapshot")
+  }
+}

--- a/src/main/scala/darkpool/engine/MatchingEngine.scala
+++ b/src/main/scala/darkpool/engine/MatchingEngine.scala
@@ -69,12 +69,12 @@ class MatchingEngine(buyOrderBook: OrderBook[Buy], sellOrderBook: OrderBook[Sell
 
     (order, top) match {
       // There is a top limit order we can match anything with
-      case (_, topLimitOrder @ LimitOrder(_, _, _, _)) =>
+      case (_, topLimitOrder @ LimitOrder(_, _, _, _, _)) =>
         if(order.crossesAt(topLimitOrder.threshold)) trade(topLimitOrder.threshold)
         else None
 
       // Match a limit order with a market order
-      case (limitOrder @ LimitOrder(_, _, _, _), MarketOrder(_, _, _)) =>
+      case (limitOrder @ LimitOrder(_, _, _, _, _), MarketOrder(_, _, _, _)) =>
         val limitThreshold = oppositeBestLimit match {
           case Some(threshold) => if (order.crossesAt(threshold)) threshold else limitOrder.threshold
           case None => limitOrder.threshold
@@ -82,7 +82,7 @@ class MatchingEngine(buyOrderBook: OrderBook[Buy], sellOrderBook: OrderBook[Sell
         trade(limitThreshold)
 
       // Match a market order with a market order
-      case (MarketOrder(_, _, _), MarketOrder(_, _, _)) =>
+      case (MarketOrder(_, _, _, _), MarketOrder(_, _, _, _)) =>
         val limitThreshold = oppositeBestLimit match {
           case Some(threshold) => threshold
           case None => marketReferencePrice match {

--- a/src/main/scala/darkpool/engine/MatchingEngine.scala
+++ b/src/main/scala/darkpool/engine/MatchingEngine.scala
@@ -32,6 +32,11 @@ class MatchingEngine(buyOrderBook: OrderBook[Buy], sellOrderBook: OrderBook[Sell
     unfilledOrder.map(book.add)
   }
 
+  def cancelOrder(order: Order) {
+    val (book, _) = getBooks(order.orderType)
+    book.cancel(order)
+  }
+
   def tryMatch(order: Order, counterBook: OrderBook[OrderType]): Option[Order] = {
     if (order.quantity == 0) None
     else counterBook.top match {

--- a/src/main/scala/darkpool/engine/commands.scala
+++ b/src/main/scala/darkpool/engine/commands.scala
@@ -5,8 +5,14 @@ import darkpool.models.orders.Order
 
 package object commands {
   case class Add(order: Order)
+  case object OrderAdded
+  case object OrderNotAdded
+
   case class Cancel(order: Order)
+  case class OrderCanceled(remainingOrder: Order)
+  case object OrderNotCanceled
+
+  case object Snapshot
   case class MarketSnapshot(spread: Double, buyBook: List[ThresholdQuantity], sellOrder: List[ThresholdQuantity],
                             referencePrice: Double)
-  case object Snapshot
 }

--- a/src/main/scala/darkpool/engine/commands.scala
+++ b/src/main/scala/darkpool/engine/commands.scala
@@ -1,0 +1,12 @@
+package darkpool.engine
+
+import darkpool.models.common.ThresholdQuantity
+import darkpool.models.orders.Order
+
+package object commands {
+  case class Add(order: Order)
+  case class Cancel(order: Order)
+  case class MarketSnapshot(spread: Double, buyBook: List[ThresholdQuantity], sellOrder: List[ThresholdQuantity],
+                            referencePrice: Double)
+  case object Snapshot
+}

--- a/src/main/scala/darkpool/models/Trade.scala
+++ b/src/main/scala/darkpool/models/Trade.scala
@@ -4,4 +4,4 @@ import java.util.UUID
 
 import darkpool.models.common.{Quantity, CreatedAt}
 
-case class Trade(buyerUUID: UUID, sellerUUID: UUID, price: Double, quantity: Double) extends CreatedAt with Quantity
+case class Trade(buyerId: UUID, sellerId: UUID, price: Double, quantity: Double) extends CreatedAt with Quantity

--- a/src/main/scala/darkpool/models/Trade.scala
+++ b/src/main/scala/darkpool/models/Trade.scala
@@ -4,4 +4,5 @@ import java.util.UUID
 
 import darkpool.models.common.{Quantity, CreatedAt}
 
-case class Trade(buyerId: UUID, sellerId: UUID, price: Double, quantity: Double) extends CreatedAt with Quantity
+case class Trade(buyerId: UUID, sellerId: UUID, buyOrderId: UUID, sellOrderId: UUID,
+                 price: Double, quantity: Double) extends CreatedAt with Quantity

--- a/src/main/scala/darkpool/models/common.scala
+++ b/src/main/scala/darkpool/models/common.scala
@@ -16,7 +16,13 @@ package object common {
     def id: UUID
   }
 
+  trait AccountID {
+    def accountId: UUID
+  }
+
   trait Quantity {
     def quantity: Double
   }
+
+  case class ThresholdQuantity(threshold: Double, quantity: Double)
 }

--- a/src/main/scala/darkpool/models/orders.scala
+++ b/src/main/scala/darkpool/models/orders.scala
@@ -73,13 +73,4 @@ package object orders {
       StopOrder(orderType, orderQuantity - quantity, orderThreshold, orderId)
   }
 
-  case class CancelOrder(orderType: OrderType, orderId: UUID)
-    extends Order {
-
-    override def decreasedBy(quantity: Double): CancelOrder = CancelOrder(orderType, orderId)
-    override def crossesAt(price: Double): Boolean = true
-    override def quantity: Double = 0.0
-    override def id: UUID = orderId
-  }
-
 }

--- a/src/main/scala/darkpool/models/orders.scala
+++ b/src/main/scala/darkpool/models/orders.scala
@@ -34,7 +34,7 @@ package object orders {
   //
   // Order Implementations
   //
-  case class MarketOrder(orderType: OrderType, orderQuantity: Double, orderId: UUID)
+  case class MarketOrder(orderType: OrderType, orderQuantity: Double, orderId: UUID, accountId: UUID)
     extends Order {
 
     override def id: UUID = orderId
@@ -42,10 +42,10 @@ package object orders {
     // Market orders accept any price
     override def crossesAt(price: Double): Boolean = true
     override def decreasedBy(quantity: Double): MarketOrder =
-      MarketOrder(orderType, orderQuantity - quantity, orderId)
+      MarketOrder(orderType, orderQuantity - quantity, orderId, accountId)
   }
 
-  case class LimitOrder(orderType: OrderType, orderQuantity: Double, orderThreshold: Double, orderId: UUID)
+  case class LimitOrder(orderType: OrderType, orderQuantity: Double, orderThreshold: Double, orderId: UUID, accountId: UUID)
     extends Order with Threshold {
 
     override def quantity: Double = orderQuantity
@@ -56,10 +56,10 @@ package object orders {
       case SellOrder => price >= threshold
     }
     override def decreasedBy(quantity: Double): LimitOrder =
-      LimitOrder(orderType, orderQuantity - quantity, orderThreshold, orderId)
+      LimitOrder(orderType, orderQuantity - quantity, orderThreshold, orderId, accountId)
   }
 
-  case class StopOrder(orderType: OrderType, orderQuantity: Double, orderThreshold: Double, orderId: UUID)
+  case class StopOrder(orderType: OrderType, orderQuantity: Double, orderThreshold: Double, orderId: UUID, accountId: UUID)
     extends Order with Threshold {
 
     override def quantity: Double = orderQuantity
@@ -70,7 +70,7 @@ package object orders {
       case SellOrder => price >= threshold
     }
     override def decreasedBy(quantity: Double): StopOrder =
-      StopOrder(orderType, orderQuantity - quantity, orderThreshold, orderId)
+      StopOrder(orderType, orderQuantity - quantity, orderThreshold, orderId, accountId)
   }
 
 }

--- a/src/main/scala/darkpool/models/orders.scala
+++ b/src/main/scala/darkpool/models/orders.scala
@@ -14,7 +14,7 @@ package object orders {
   }
   trait Buy extends OrderType
   trait Sell extends OrderType
-  trait Order extends Quantity with CreatedAt with ID {
+  trait Order extends Quantity with CreatedAt with ID with AccountID {
     def decreasedBy(quantity: Double): Order
     def crossesAt(price: Double): Boolean
     // TODO: Rename this awful name

--- a/src/test/scala/darkpool/book/OrderBookBestLimitSpec.scala
+++ b/src/test/scala/darkpool/book/OrderBookBestLimitSpec.scala
@@ -21,28 +21,28 @@ class OrderBookBestLimitSpec extends FunSpec with Matchers with BeforeAndAfter {
     }
 
     it("does not have a best limit order given only market orders") {
-      orderBookBuy.add(MarketOrder(BuyOrder, 100, UUID.randomUUID()))
-      orderBookSell.add(MarketOrder(BuyOrder, 100, UUID.randomUUID()))
+      orderBookBuy.add(MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
+      orderBookSell.add(MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
 
       orderBookBuy.bestLimit shouldBe None
       orderBookSell.bestLimit shouldBe None
     }
 
     it("various life cycles of the order book best limit for BUY") {
-      val marketOrder = MarketOrder(BuyOrder, 100, UUID.randomUUID())
+      val marketOrder = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(marketOrder)
-      val firstOrder = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      val firstOrder = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(firstOrder)
 
       orderBookBuy.bestLimit.get shouldBe firstOrder.threshold
       orderBookBuy.orders shouldBe List(marketOrder, firstOrder)
 
-      val conservativeOrder = LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID())
+      val conservativeOrder = LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(conservativeOrder)
       orderBookBuy.bestLimit.get shouldBe firstOrder.threshold
       orderBookBuy.orders shouldBe List(marketOrder, firstOrder, conservativeOrder)
 
-      val aggressiveOrder = LimitOrder(BuyOrder, 100, 10.6, UUID.randomUUID())
+      val aggressiveOrder = LimitOrder(BuyOrder, 100, 10.6, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(aggressiveOrder)
       orderBookBuy.bestLimit.get shouldBe aggressiveOrder.threshold
       orderBookBuy.orders shouldBe List(marketOrder, aggressiveOrder, firstOrder, conservativeOrder)
@@ -61,20 +61,20 @@ class OrderBookBestLimitSpec extends FunSpec with Matchers with BeforeAndAfter {
     }
 
     it("various life cycles of the order book best limit for SELL") {
-      val marketOrder = MarketOrder(SellOrder, 100, UUID.randomUUID())
+      val marketOrder = MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID())
       orderBookSell.add(marketOrder)
-      val firstOrder = LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID())
+      val firstOrder = LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBookSell.add(firstOrder)
 
       orderBookSell.bestLimit.get shouldBe firstOrder.threshold
       orderBookSell.orders shouldBe List(marketOrder, firstOrder)
 
-      val conservativeOrder = LimitOrder(SellOrder, 100, 10.6, UUID.randomUUID())
+      val conservativeOrder = LimitOrder(SellOrder, 100, 10.6, UUID.randomUUID(), UUID.randomUUID())
       orderBookSell.add(conservativeOrder)
       orderBookSell.bestLimit.get shouldBe firstOrder.threshold
       orderBookSell.orders shouldBe List(marketOrder, firstOrder, conservativeOrder)
 
-      val aggressiveOrder = LimitOrder(SellOrder, 100, 10.4, UUID.randomUUID())
+      val aggressiveOrder = LimitOrder(SellOrder, 100, 10.4, UUID.randomUUID(), UUID.randomUUID())
       orderBookSell.add(aggressiveOrder)
       orderBookSell.bestLimit.get shouldBe aggressiveOrder.threshold
       orderBookSell.orders shouldBe List(marketOrder, aggressiveOrder, firstOrder, conservativeOrder)

--- a/src/test/scala/darkpool/book/OrderBookBestLimitSpec.scala
+++ b/src/test/scala/darkpool/book/OrderBookBestLimitSpec.scala
@@ -21,8 +21,8 @@ class OrderBookBestLimitSpec extends FunSpec with Matchers with BeforeAndAfter {
     }
 
     it("does not have a best limit order given only market orders") {
-      orderBookBuy.add(MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
-      orderBookSell.add(MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
+      orderBookBuy.addOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
+      orderBookSell.addOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
 
       orderBookBuy.bestLimit shouldBe None
       orderBookSell.bestLimit shouldBe None
@@ -30,20 +30,20 @@ class OrderBookBestLimitSpec extends FunSpec with Matchers with BeforeAndAfter {
 
     it("various life cycles of the order book best limit for BUY") {
       val marketOrder = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(marketOrder)
+      orderBookBuy.addOrder(marketOrder)
       val firstOrder = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(firstOrder)
+      orderBookBuy.addOrder(firstOrder)
 
       orderBookBuy.bestLimit.get shouldBe firstOrder.threshold
       orderBookBuy.orders shouldBe List(marketOrder, firstOrder)
 
       val conservativeOrder = LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(conservativeOrder)
+      orderBookBuy.addOrder(conservativeOrder)
       orderBookBuy.bestLimit.get shouldBe firstOrder.threshold
       orderBookBuy.orders shouldBe List(marketOrder, firstOrder, conservativeOrder)
 
       val aggressiveOrder = LimitOrder(BuyOrder, 100, 10.6, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(aggressiveOrder)
+      orderBookBuy.addOrder(aggressiveOrder)
       orderBookBuy.bestLimit.get shouldBe aggressiveOrder.threshold
       orderBookBuy.orders shouldBe List(marketOrder, aggressiveOrder, firstOrder, conservativeOrder)
 
@@ -62,20 +62,20 @@ class OrderBookBestLimitSpec extends FunSpec with Matchers with BeforeAndAfter {
 
     it("various life cycles of the order book best limit for SELL") {
       val marketOrder = MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID())
-      orderBookSell.add(marketOrder)
+      orderBookSell.addOrder(marketOrder)
       val firstOrder = LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBookSell.add(firstOrder)
+      orderBookSell.addOrder(firstOrder)
 
       orderBookSell.bestLimit.get shouldBe firstOrder.threshold
       orderBookSell.orders shouldBe List(marketOrder, firstOrder)
 
       val conservativeOrder = LimitOrder(SellOrder, 100, 10.6, UUID.randomUUID(), UUID.randomUUID())
-      orderBookSell.add(conservativeOrder)
+      orderBookSell.addOrder(conservativeOrder)
       orderBookSell.bestLimit.get shouldBe firstOrder.threshold
       orderBookSell.orders shouldBe List(marketOrder, firstOrder, conservativeOrder)
 
       val aggressiveOrder = LimitOrder(SellOrder, 100, 10.4, UUID.randomUUID(), UUID.randomUUID())
-      orderBookSell.add(aggressiveOrder)
+      orderBookSell.addOrder(aggressiveOrder)
       orderBookSell.bestLimit.get shouldBe aggressiveOrder.threshold
       orderBookSell.orders shouldBe List(marketOrder, aggressiveOrder, firstOrder, conservativeOrder)
 

--- a/src/test/scala/darkpool/book/OrderBookCancelSpec.scala
+++ b/src/test/scala/darkpool/book/OrderBookCancelSpec.scala
@@ -16,81 +16,81 @@ class OrderBookCancelSpec extends FunSpec with Matchers with BeforeAndAfter {
     it("cant find an order that doesnt exist") {
       val limitOrder = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       val marketOrder = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
-      orderBook.cancel(limitOrder)
-      orderBook.cancel(marketOrder)
+      orderBook.cancelOrder(limitOrder)
+      orderBook.cancelOrder(marketOrder)
       orderBook.orders shouldBe Nil
       orderBook.canceledOrders shouldBe Nil
 
-      orderBook.add(LimitOrder(BuyOrder, 20, 10.5, UUID.randomUUID(), UUID.randomUUID()))
+      orderBook.addOrder(LimitOrder(BuyOrder, 20, 10.5, UUID.randomUUID(), UUID.randomUUID()))
 
-      orderBook.cancel(limitOrder)
-      orderBook.cancel(marketOrder)
+      orderBook.cancelOrder(limitOrder)
+      orderBook.cancelOrder(marketOrder)
       orderBook.orders.size shouldBe 1
       orderBook.canceledOrders shouldBe Nil
     }
 
     it("can cancel an unfulfilled limit order") {
       val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBook.add(order)
+      orderBook.addOrder(order)
       orderBook.orders shouldBe List(order)
 
-      orderBook.cancel(order)
+      orderBook.cancelOrder(order)
       orderBook.orders shouldBe Nil
       orderBook.canceledOrders shouldBe List(order)
     }
 
     it("can cancel an unfulfilled limit order when multiple limit orders at threshold exist") {
       val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBook.add(order)
+      orderBook.addOrder(order)
       val order2 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBook.add(order2)
+      orderBook.addOrder(order2)
       orderBook.orders shouldBe List(order, order2)
 
-      orderBook.cancel(order)
+      orderBook.cancelOrder(order)
       orderBook.orders shouldBe List(order2)
       orderBook.canceledOrders shouldBe List(order)
     }
 
     it("can cancel an unfulfilled limit order when multiple limit orders at different threshold exist") {
       val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBook.add(order)
+      orderBook.addOrder(order)
       val order2 = LimitOrder(BuyOrder, 50, 10.2, UUID.randomUUID(), UUID.randomUUID())
-      orderBook.add(order2)
+      orderBook.addOrder(order2)
       orderBook.orders shouldBe List(order, order2)
 
-      orderBook.cancel(order)
+      orderBook.cancelOrder(order)
       orderBook.orders shouldBe List(order2)
       orderBook.canceledOrders shouldBe List(order)
     }
 
     it("can cancel an unfulfilled market order") {
       val order = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
-      orderBook.add(order)
+      orderBook.addOrder(order)
       orderBook.orders shouldBe List(order)
 
-      orderBook.cancel(order)
+      orderBook.cancelOrder(order)
       orderBook.orders shouldBe Nil
       orderBook.canceledOrders shouldBe List(order)
     }
 
     it("can cancel an unfulfilled market order when multiple market orders exist") {
       val order = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
-      orderBook.add(order)
+      orderBook.addOrder(order)
       val order2 = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
-      orderBook.add(order2)
+      orderBook.addOrder(order2)
 
       orderBook.orders shouldBe List(order, order2)
 
-      orderBook.cancel(order)
+      orderBook.cancelOrder(order)
       orderBook.orders shouldBe List(order2)
       orderBook.canceledOrders shouldBe List(order)
     }
 
     it("can cancel a partially matched order") {
       val limitOrder = LimitOrder(BuyOrder, 140, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBook.add(limitOrder)
+      orderBook.addOrder(limitOrder)
       orderBook.decreaseTopBy(100)
-      orderBook.cancel(limitOrder)
+      orderBook.cancelOrder(limitOrder)
 
       orderBook.canceledOrders.head.quantity shouldBe 40
       orderBook.canceledOrders.head.id shouldBe limitOrder.id
@@ -99,10 +99,10 @@ class OrderBookCancelSpec extends FunSpec with Matchers with BeforeAndAfter {
 
     it("can cancel a partially matched order with multiple orders") {
       val limitOrder = LimitOrder(BuyOrder, 140, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBook.add(limitOrder)
-      orderBook.add(LimitOrder(BuyOrder, 123, 10.2, UUID.randomUUID(), UUID.randomUUID()))
+      orderBook.addOrder(limitOrder)
+      orderBook.addOrder(LimitOrder(BuyOrder, 123, 10.2, UUID.randomUUID(), UUID.randomUUID()))
       orderBook.decreaseTopBy(100)
-      orderBook.cancel(limitOrder)
+      orderBook.cancelOrder(limitOrder)
 
       orderBook.canceledOrders.head.quantity shouldBe 40
       orderBook.canceledOrders.head.id shouldBe limitOrder.id

--- a/src/test/scala/darkpool/book/OrderBookCancelSpec.scala
+++ b/src/test/scala/darkpool/book/OrderBookCancelSpec.scala
@@ -14,14 +14,14 @@ class OrderBookCancelSpec extends FunSpec with Matchers with BeforeAndAfter {
 
   describe("Canceling an Order") {
     it("cant find an order that doesnt exist") {
-      val limitOrder = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
-      val marketOrder = MarketOrder(BuyOrder, 100, UUID.randomUUID())
+      val limitOrder = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
+      val marketOrder = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
       orderBook.cancel(limitOrder)
       orderBook.cancel(marketOrder)
       orderBook.orders shouldBe Nil
       orderBook.canceledOrders shouldBe Nil
 
-      orderBook.add(LimitOrder(BuyOrder, 20, 10.5, UUID.randomUUID()))
+      orderBook.add(LimitOrder(BuyOrder, 20, 10.5, UUID.randomUUID(), UUID.randomUUID()))
 
       orderBook.cancel(limitOrder)
       orderBook.cancel(marketOrder)
@@ -30,7 +30,7 @@ class OrderBookCancelSpec extends FunSpec with Matchers with BeforeAndAfter {
     }
 
     it("can cancel an unfulfilled limit order") {
-      val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBook.add(order)
       orderBook.orders shouldBe List(order)
 
@@ -40,9 +40,9 @@ class OrderBookCancelSpec extends FunSpec with Matchers with BeforeAndAfter {
     }
 
     it("can cancel an unfulfilled limit order when multiple limit orders at threshold exist") {
-      val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBook.add(order)
-      val order2 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      val order2 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBook.add(order2)
       orderBook.orders shouldBe List(order, order2)
 
@@ -52,9 +52,9 @@ class OrderBookCancelSpec extends FunSpec with Matchers with BeforeAndAfter {
     }
 
     it("can cancel an unfulfilled limit order when multiple limit orders at different threshold exist") {
-      val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBook.add(order)
-      val order2 = LimitOrder(BuyOrder, 50, 10.2, UUID.randomUUID())
+      val order2 = LimitOrder(BuyOrder, 50, 10.2, UUID.randomUUID(), UUID.randomUUID())
       orderBook.add(order2)
       orderBook.orders shouldBe List(order, order2)
 
@@ -64,7 +64,7 @@ class OrderBookCancelSpec extends FunSpec with Matchers with BeforeAndAfter {
     }
 
     it("can cancel an unfulfilled market order") {
-      val order = MarketOrder(BuyOrder, 100, UUID.randomUUID())
+      val order = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
       orderBook.add(order)
       orderBook.orders shouldBe List(order)
 
@@ -74,9 +74,9 @@ class OrderBookCancelSpec extends FunSpec with Matchers with BeforeAndAfter {
     }
 
     it("can cancel an unfulfilled market order when multiple market orders exist") {
-      val order = MarketOrder(BuyOrder, 100, UUID.randomUUID())
+      val order = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
       orderBook.add(order)
-      val order2 = MarketOrder(BuyOrder, 100, UUID.randomUUID())
+      val order2 = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
       orderBook.add(order2)
 
       orderBook.orders shouldBe List(order, order2)
@@ -87,7 +87,7 @@ class OrderBookCancelSpec extends FunSpec with Matchers with BeforeAndAfter {
     }
 
     it("can cancel a partially matched order") {
-      val limitOrder = LimitOrder(BuyOrder, 140, 10.5, UUID.randomUUID())
+      val limitOrder = LimitOrder(BuyOrder, 140, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBook.add(limitOrder)
       orderBook.decreaseTopBy(100)
       orderBook.cancel(limitOrder)
@@ -98,9 +98,9 @@ class OrderBookCancelSpec extends FunSpec with Matchers with BeforeAndAfter {
     }
 
     it("can cancel a partially matched order with multiple orders") {
-      val limitOrder = LimitOrder(BuyOrder, 140, 10.5, UUID.randomUUID())
+      val limitOrder = LimitOrder(BuyOrder, 140, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBook.add(limitOrder)
-      orderBook.add(LimitOrder(BuyOrder, 123, 10.2, UUID.randomUUID()))
+      orderBook.add(LimitOrder(BuyOrder, 123, 10.2, UUID.randomUUID(), UUID.randomUUID()))
       orderBook.decreaseTopBy(100)
       orderBook.cancel(limitOrder)
 
@@ -108,5 +108,6 @@ class OrderBookCancelSpec extends FunSpec with Matchers with BeforeAndAfter {
       orderBook.canceledOrders.head.id shouldBe limitOrder.id
       orderBook.top.get.quantity shouldBe 123
     }
+
   }
 }

--- a/src/test/scala/darkpool/book/OrderBookCancelSpec.scala
+++ b/src/test/scala/darkpool/book/OrderBookCancelSpec.scala
@@ -1,0 +1,112 @@
+package darkpool.book
+
+import java.util.UUID
+
+import darkpool.models.orders.{BuyOrder, LimitOrder, MarketOrder}
+import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+
+class OrderBookCancelSpec extends FunSpec with Matchers with BeforeAndAfter {
+  var orderBook = new OrderBook(BuyOrder)
+
+  before {
+    orderBook = new OrderBook(BuyOrder)
+  }
+
+  describe("Canceling an Order") {
+    it("cant find an order that doesnt exist") {
+      val limitOrder = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      val marketOrder = MarketOrder(BuyOrder, 100, UUID.randomUUID())
+      orderBook.cancel(limitOrder)
+      orderBook.cancel(marketOrder)
+      orderBook.orders shouldBe Nil
+      orderBook.canceledOrders shouldBe Nil
+
+      orderBook.add(LimitOrder(BuyOrder, 20, 10.5, UUID.randomUUID()))
+
+      orderBook.cancel(limitOrder)
+      orderBook.cancel(marketOrder)
+      orderBook.orders.size shouldBe 1
+      orderBook.canceledOrders shouldBe Nil
+    }
+
+    it("can cancel an unfulfilled limit order") {
+      val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      orderBook.add(order)
+      orderBook.orders shouldBe List(order)
+
+      orderBook.cancel(order)
+      orderBook.orders shouldBe Nil
+      orderBook.canceledOrders shouldBe List(order)
+    }
+
+    it("can cancel an unfulfilled limit order when multiple limit orders at threshold exist") {
+      val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      orderBook.add(order)
+      val order2 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      orderBook.add(order2)
+      orderBook.orders shouldBe List(order, order2)
+
+      orderBook.cancel(order)
+      orderBook.orders shouldBe List(order2)
+      orderBook.canceledOrders shouldBe List(order)
+    }
+
+    it("can cancel an unfulfilled limit order when multiple limit orders at different threshold exist") {
+      val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      orderBook.add(order)
+      val order2 = LimitOrder(BuyOrder, 50, 10.2, UUID.randomUUID())
+      orderBook.add(order2)
+      orderBook.orders shouldBe List(order, order2)
+
+      orderBook.cancel(order)
+      orderBook.orders shouldBe List(order2)
+      orderBook.canceledOrders shouldBe List(order)
+    }
+
+    it("can cancel an unfulfilled market order") {
+      val order = MarketOrder(BuyOrder, 100, UUID.randomUUID())
+      orderBook.add(order)
+      orderBook.orders shouldBe List(order)
+
+      orderBook.cancel(order)
+      orderBook.orders shouldBe Nil
+      orderBook.canceledOrders shouldBe List(order)
+    }
+
+    it("can cancel an unfulfilled market order when multiple market orders exist") {
+      val order = MarketOrder(BuyOrder, 100, UUID.randomUUID())
+      orderBook.add(order)
+      val order2 = MarketOrder(BuyOrder, 100, UUID.randomUUID())
+      orderBook.add(order2)
+
+      orderBook.orders shouldBe List(order, order2)
+
+      orderBook.cancel(order)
+      orderBook.orders shouldBe List(order2)
+      orderBook.canceledOrders shouldBe List(order)
+    }
+
+    it("can cancel a partially matched order") {
+      val limitOrder = LimitOrder(BuyOrder, 140, 10.5, UUID.randomUUID())
+      orderBook.add(limitOrder)
+      orderBook.decreaseTopBy(100)
+      orderBook.cancel(limitOrder)
+
+      orderBook.canceledOrders.head.quantity shouldBe 40
+      orderBook.canceledOrders.head.id shouldBe limitOrder.id
+      orderBook.top shouldBe None
+    }
+
+    it("can cancel a partially matched order with multiple orders") {
+      val limitOrder = LimitOrder(BuyOrder, 140, 10.5, UUID.randomUUID())
+      orderBook.add(limitOrder)
+      orderBook.add(LimitOrder(BuyOrder, 123, 10.2, UUID.randomUUID()))
+      orderBook.decreaseTopBy(100)
+      orderBook.cancel(limitOrder)
+
+      orderBook.canceledOrders.head.quantity shouldBe 40
+      orderBook.canceledOrders.head.id shouldBe limitOrder.id
+      orderBook.top.get.quantity shouldBe 123
+    }
+  }
+}

--- a/src/test/scala/darkpool/book/OrderBookLimitOrdersSpec.scala
+++ b/src/test/scala/darkpool/book/OrderBookLimitOrdersSpec.scala
@@ -17,7 +17,7 @@ class OrderBookLimitOrdersSpec extends FunSpec with Matchers with BeforeAndAfter
   describe("Price and time priority of limit orders") {
     it("can add a single limit order to the BUY order book") {
       val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(order)
+      orderBookBuy.addOrder(order)
       orderBookBuy.orders.size shouldBe 1
       orderBookBuy.top.get shouldBe order
     }
@@ -25,30 +25,30 @@ class OrderBookLimitOrdersSpec extends FunSpec with Matchers with BeforeAndAfter
     it("can add two limit orders to the BUY order book, with more aggressive order first") {
       val order1 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       val order2 = LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(order1)
-      orderBookBuy.add(order2)
+      orderBookBuy.addOrder(order1)
+      orderBookBuy.addOrder(order2)
       orderBookBuy.orders shouldBe List(order1, order2)
     }
 
     it("can add two limit orders to the BUY order book, with less aggressive order first") {
       val order1 = LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID(), UUID.randomUUID())
       val order2 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(order1)
-      orderBookBuy.add(order2)
+      orderBookBuy.addOrder(order1)
+      orderBookBuy.addOrder(order2)
       orderBookBuy.orders shouldBe List(order2, order1)
     }
 
     it("can add two limit orders to the BUY order book, with the same price limit") {
       val order1 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       val order2 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(order1)
-      orderBookBuy.add(order2)
+      orderBookBuy.addOrder(order1)
+      orderBookBuy.addOrder(order2)
       orderBookBuy.orders shouldBe List(order1, order2)
     }
 
     it("can add a single limit order to the SELL order book") {
       val order = LimitOrder(SellOrder, 100, 10.6, UUID.randomUUID(), UUID.randomUUID())
-      orderBookSell.add(order)
+      orderBookSell.addOrder(order)
       orderBookSell.orders.size shouldBe 1
       orderBookSell.top.get shouldBe order
     }
@@ -56,24 +56,24 @@ class OrderBookLimitOrdersSpec extends FunSpec with Matchers with BeforeAndAfter
     it("can add two limit orders to the SELL order book, with more aggressive order first") {
       val order1 = LimitOrder(SellOrder, 100, 10.6, UUID.randomUUID(), UUID.randomUUID())
       val order2 = LimitOrder(SellOrder, 100, 10.7, UUID.randomUUID(), UUID.randomUUID())
-      orderBookSell.add(order1)
-      orderBookSell.add(order2)
+      orderBookSell.addOrder(order1)
+      orderBookSell.addOrder(order2)
       orderBookSell.orders shouldBe List(order1, order2)
     }
 
     it("can add two limit orders to the SELL order book, with the same price limit") {
       val order1 = LimitOrder(SellOrder, 100, 10.7, UUID.randomUUID(), UUID.randomUUID())
       val order2 = LimitOrder(SellOrder, 100, 10.7, UUID.randomUUID(), UUID.randomUUID())
-      orderBookSell.add(order1)
-      orderBookSell.add(order2)
+      orderBookSell.addOrder(order1)
+      orderBookSell.addOrder(order2)
       orderBookSell.orders shouldBe List(order1, order2)
     }
 
     it("can decrease top outstanding order partially and then fill it completely") {
       val order1 = LimitOrder(BuyOrder, 100, 10000.7, UUID.randomUUID(), UUID.randomUUID())
       val order2 = LimitOrder(BuyOrder, 100, 10000.7, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(order1)
-      orderBookBuy.add(order2)
+      orderBookBuy.addOrder(order1)
+      orderBookBuy.addOrder(order2)
 
       orderBookBuy.decreaseTopBy(20)
       orderBookBuy.orders.size shouldBe 2

--- a/src/test/scala/darkpool/book/OrderBookLimitOrdersSpec.scala
+++ b/src/test/scala/darkpool/book/OrderBookLimitOrdersSpec.scala
@@ -16,62 +16,62 @@ class OrderBookLimitOrdersSpec extends FunSpec with Matchers with BeforeAndAfter
 
   describe("Price and time priority of limit orders") {
     it("can add a single limit order to the BUY order book") {
-      val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      val order = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(order)
       orderBookBuy.orders.size shouldBe 1
       orderBookBuy.top.get shouldBe order
     }
 
     it("can add two limit orders to the BUY order book, with more aggressive order first") {
-      val order1 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
-      val order2 = LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID())
+      val order1 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
+      val order2 = LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(order1)
       orderBookBuy.add(order2)
       orderBookBuy.orders shouldBe List(order1, order2)
     }
 
     it("can add two limit orders to the BUY order book, with less aggressive order first") {
-      val order1 = LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID())
-      val order2 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      val order1 = LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID(), UUID.randomUUID())
+      val order2 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(order1)
       orderBookBuy.add(order2)
       orderBookBuy.orders shouldBe List(order2, order1)
     }
 
     it("can add two limit orders to the BUY order book, with the same price limit") {
-      val order1 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
-      val order2 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      val order1 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
+      val order2 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(order1)
       orderBookBuy.add(order2)
       orderBookBuy.orders shouldBe List(order1, order2)
     }
 
     it("can add a single limit order to the SELL order book") {
-      val order = LimitOrder(SellOrder, 100, 10.6, UUID.randomUUID())
+      val order = LimitOrder(SellOrder, 100, 10.6, UUID.randomUUID(), UUID.randomUUID())
       orderBookSell.add(order)
       orderBookSell.orders.size shouldBe 1
       orderBookSell.top.get shouldBe order
     }
 
     it("can add two limit orders to the SELL order book, with more aggressive order first") {
-      val order1 = LimitOrder(SellOrder, 100, 10.6, UUID.randomUUID())
-      val order2 = LimitOrder(SellOrder, 100, 10.7, UUID.randomUUID())
+      val order1 = LimitOrder(SellOrder, 100, 10.6, UUID.randomUUID(), UUID.randomUUID())
+      val order2 = LimitOrder(SellOrder, 100, 10.7, UUID.randomUUID(), UUID.randomUUID())
       orderBookSell.add(order1)
       orderBookSell.add(order2)
       orderBookSell.orders shouldBe List(order1, order2)
     }
 
     it("can add two limit orders to the SELL order book, with the same price limit") {
-      val order1 = LimitOrder(SellOrder, 100, 10.7, UUID.randomUUID())
-      val order2 = LimitOrder(SellOrder, 100, 10.7, UUID.randomUUID())
+      val order1 = LimitOrder(SellOrder, 100, 10.7, UUID.randomUUID(), UUID.randomUUID())
+      val order2 = LimitOrder(SellOrder, 100, 10.7, UUID.randomUUID(), UUID.randomUUID())
       orderBookSell.add(order1)
       orderBookSell.add(order2)
       orderBookSell.orders shouldBe List(order1, order2)
     }
 
     it("can decrease top outstanding order partially and then fill it completely") {
-      val order1 = LimitOrder(BuyOrder, 100, 10000.7, UUID.randomUUID())
-      val order2 = LimitOrder(BuyOrder, 100, 10000.7, UUID.randomUUID())
+      val order1 = LimitOrder(BuyOrder, 100, 10000.7, UUID.randomUUID(), UUID.randomUUID())
+      val order2 = LimitOrder(BuyOrder, 100, 10000.7, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(order1)
       orderBookBuy.add(order2)
 

--- a/src/test/scala/darkpool/book/OrderBookMarketSpec.scala
+++ b/src/test/scala/darkpool/book/OrderBookMarketSpec.scala
@@ -16,57 +16,57 @@ class OrderBookMarketSpec extends FunSpec with Matchers with BeforeAndAfter {
 
   describe("Price and time priority of market orders over limit orders") {
     it("buy book: market order has priority over a limit order") {
-      val limitOrder = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      val limitOrder = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(limitOrder)
       orderBookBuy.orders shouldBe List(limitOrder)
 
-      val marketOrder = MarketOrder(BuyOrder, 100, UUID.randomUUID())
+      val marketOrder = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(marketOrder)
       orderBookBuy.orders shouldBe List(marketOrder, limitOrder)
     }
 
     it("buy book: can correctly queue multiple market orders and limit orders") {
-      val limitOrder = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      val limitOrder = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(limitOrder)
       orderBookBuy.orders shouldBe List(limitOrder)
 
-      val marketOrder = MarketOrder(BuyOrder, 100, UUID.randomUUID())
+      val marketOrder = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(marketOrder)
       orderBookBuy.orders shouldBe List(marketOrder, limitOrder)
 
-      val limitOrder2 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID())
+      val limitOrder2 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(limitOrder2)
       orderBookBuy.orders shouldBe List(marketOrder, limitOrder, limitOrder2)
 
-      val marketOrder2 = MarketOrder(BuyOrder, 100, UUID.randomUUID())
+      val marketOrder2 = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
       orderBookBuy.add(marketOrder2)
       orderBookBuy.orders shouldBe List(marketOrder, marketOrder2, limitOrder, limitOrder2)
     }
 
     it("sell book: market order has priority over a limit order") {
-      val limitOrder = LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID())
+      val limitOrder = LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBookSell.add(limitOrder)
       orderBookSell.orders shouldBe List(limitOrder)
 
-      val marketOrder = MarketOrder(SellOrder, 100, UUID.randomUUID())
+      val marketOrder = MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID())
       orderBookSell.add(marketOrder)
       orderBookSell.orders shouldBe List(marketOrder, limitOrder)
     }
 
     it("sell book: can correctly queue multiple market orders and limit orders") {
-      val limitOrder = LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID())
+      val limitOrder = LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBookSell.add(limitOrder)
       orderBookSell.orders shouldBe List(limitOrder)
 
-      val marketOrder = MarketOrder(SellOrder, 100, UUID.randomUUID())
+      val marketOrder = MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID())
       orderBookSell.add(marketOrder)
       orderBookSell.orders shouldBe List(marketOrder, limitOrder)
 
-      val limitOrder2 = LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID())
+      val limitOrder2 = LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
       orderBookSell.add(limitOrder2)
       orderBookSell.orders shouldBe List(marketOrder, limitOrder, limitOrder2)
 
-      val marketOrder2 = MarketOrder(SellOrder, 100, UUID.randomUUID())
+      val marketOrder2 = MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID())
       orderBookSell.add(marketOrder2)
       orderBookSell.orders shouldBe List(marketOrder, marketOrder2, limitOrder, limitOrder2)
     }

--- a/src/test/scala/darkpool/book/OrderBookMarketSpec.scala
+++ b/src/test/scala/darkpool/book/OrderBookMarketSpec.scala
@@ -17,57 +17,57 @@ class OrderBookMarketSpec extends FunSpec with Matchers with BeforeAndAfter {
   describe("Price and time priority of market orders over limit orders") {
     it("buy book: market order has priority over a limit order") {
       val limitOrder = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(limitOrder)
+      orderBookBuy.addOrder(limitOrder)
       orderBookBuy.orders shouldBe List(limitOrder)
 
       val marketOrder = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(marketOrder)
+      orderBookBuy.addOrder(marketOrder)
       orderBookBuy.orders shouldBe List(marketOrder, limitOrder)
     }
 
     it("buy book: can correctly queue multiple market orders and limit orders") {
       val limitOrder = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(limitOrder)
+      orderBookBuy.addOrder(limitOrder)
       orderBookBuy.orders shouldBe List(limitOrder)
 
       val marketOrder = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(marketOrder)
+      orderBookBuy.addOrder(marketOrder)
       orderBookBuy.orders shouldBe List(marketOrder, limitOrder)
 
       val limitOrder2 = LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(limitOrder2)
+      orderBookBuy.addOrder(limitOrder2)
       orderBookBuy.orders shouldBe List(marketOrder, limitOrder, limitOrder2)
 
       val marketOrder2 = MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID())
-      orderBookBuy.add(marketOrder2)
+      orderBookBuy.addOrder(marketOrder2)
       orderBookBuy.orders shouldBe List(marketOrder, marketOrder2, limitOrder, limitOrder2)
     }
 
     it("sell book: market order has priority over a limit order") {
       val limitOrder = LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBookSell.add(limitOrder)
+      orderBookSell.addOrder(limitOrder)
       orderBookSell.orders shouldBe List(limitOrder)
 
       val marketOrder = MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID())
-      orderBookSell.add(marketOrder)
+      orderBookSell.addOrder(marketOrder)
       orderBookSell.orders shouldBe List(marketOrder, limitOrder)
     }
 
     it("sell book: can correctly queue multiple market orders and limit orders") {
       val limitOrder = LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBookSell.add(limitOrder)
+      orderBookSell.addOrder(limitOrder)
       orderBookSell.orders shouldBe List(limitOrder)
 
       val marketOrder = MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID())
-      orderBookSell.add(marketOrder)
+      orderBookSell.addOrder(marketOrder)
       orderBookSell.orders shouldBe List(marketOrder, limitOrder)
 
       val limitOrder2 = LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID())
-      orderBookSell.add(limitOrder2)
+      orderBookSell.addOrder(limitOrder2)
       orderBookSell.orders shouldBe List(marketOrder, limitOrder, limitOrder2)
 
       val marketOrder2 = MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID())
-      orderBookSell.add(marketOrder2)
+      orderBookSell.addOrder(marketOrder2)
       orderBookSell.orders shouldBe List(marketOrder, marketOrder2, limitOrder, limitOrder2)
     }
   }

--- a/src/test/scala/darkpool/engine/MatchingEngineAkkaInterfaceSpec.scala
+++ b/src/test/scala/darkpool/engine/MatchingEngineAkkaInterfaceSpec.scala
@@ -1,0 +1,36 @@
+package darkpool.engine
+
+import java.util.UUID
+
+import akka.actor.{Props, ActorSystem}
+import darkpool.actors.{QueryActor, MatchingEngineActor}
+import darkpool.book.OrderBook
+import darkpool.models.orders.{LimitOrder, SellOrder, BuyOrder}
+import org.scalatest.{BeforeAndAfter, Matchers, FunSpec}
+import darkpool.engine.commands._
+
+class MatchingEngineAkkaInterfaceSpec extends FunSpec with Matchers with BeforeAndAfter {
+
+  describe("Use akka interface into matching engine") {
+    val orderBookBuy = new OrderBook(BuyOrder)
+    val orderBookSell = new OrderBook(SellOrder)
+
+    it("should receive orders and generate a snapshot when asked") {
+      val system = ActorSystem("darkpool-testing")
+      val engine = system.actorOf(Props(new MatchingEngineActor(orderBookBuy, orderBookSell)), "engine")
+      system.actorOf(Props[QueryActor], "api")
+
+      engine ! Add(LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID(), UUID.randomUUID()))
+      engine ! Add(LimitOrder(BuyOrder, 200, 10.4, UUID.randomUUID(), UUID.randomUUID()))
+      engine ! Add(LimitOrder(BuyOrder, 50, 10.4, UUID.randomUUID(), UUID.randomUUID()))
+      engine ! Add(LimitOrder(BuyOrder, 30, 10.4, UUID.randomUUID(), UUID.randomUUID()))
+
+      engine ! Add(LimitOrder(SellOrder, 50, 11, UUID.randomUUID(), UUID.randomUUID()))
+      engine ! Add(LimitOrder(SellOrder, 50, 10.2, UUID.randomUUID(), UUID.randomUUID()))
+
+      Thread.sleep(1000)
+
+      engine ! Snapshot
+    }
+  }
+}

--- a/src/test/scala/darkpool/engine/MatchingEngineAkkaInterfaceSpec.scala
+++ b/src/test/scala/darkpool/engine/MatchingEngineAkkaInterfaceSpec.scala
@@ -2,35 +2,53 @@ package darkpool.engine
 
 import java.util.UUID
 
-import akka.actor.{Props, ActorSystem}
-import darkpool.actors.{QueryActor, MatchingEngineActor}
+import akka.actor.{ActorSystem, Props}
+import akka.testkit.{DefaultTimeout, ImplicitSender, TestKit}
+import darkpool.actors.{LedgerActor, MatchingEngineActor, QueryActor}
 import darkpool.book.OrderBook
-import darkpool.models.orders.{LimitOrder, SellOrder, BuyOrder}
-import org.scalatest.{BeforeAndAfter, Matchers, FunSpec}
 import darkpool.engine.commands._
+import darkpool.models.orders.{BuyOrder, LimitOrder, MarketOrder, SellOrder}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpecLike, Matchers}
 
-class MatchingEngineAkkaInterfaceSpec extends FunSpec with Matchers with BeforeAndAfter {
+import scala.concurrent.duration._
+
+class MatchingEngineAkkaInterfaceSpec
+  extends TestKit(ActorSystem("MatchingEngineAkkaInterfaceSpec"))
+  with DefaultTimeout with ImplicitSender
+  with FunSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
+
+  val orderBookBuy = new OrderBook(BuyOrder)
+  val orderBookSell = new OrderBook(SellOrder)
+  val engineActor = system.actorOf(Props(new MatchingEngineActor(orderBookBuy, orderBookSell)), "engineActor")
+  val apiActor = system.actorOf(Props[QueryActor], "api")
+  val ledgerActor = system.actorOf(Props[LedgerActor], "ledger")
 
   describe("Use akka interface into matching engine") {
-    val orderBookBuy = new OrderBook(BuyOrder)
-    val orderBookSell = new OrderBook(SellOrder)
-
     it("should receive orders and generate a snapshot when asked") {
-      val system = ActorSystem("darkpool-testing")
-      val engine = system.actorOf(Props(new MatchingEngineActor(orderBookBuy, orderBookSell)), "engine")
-      system.actorOf(Props[QueryActor], "api")
+      within(1 second) {
+        engineActor ! Add(LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID(), UUID.randomUUID()))
+        expectMsg(OrderAdded)
+        engineActor ! Add(LimitOrder(BuyOrder, 200, 10.4, UUID.randomUUID(), UUID.randomUUID()))
+        expectMsg(OrderAdded)
+        engineActor ! Add(LimitOrder(BuyOrder, 50, 10.4, UUID.randomUUID(), UUID.randomUUID()))
+        expectMsg(OrderAdded)
+        engineActor ! Add(MarketOrder(BuyOrder, 30, UUID.randomUUID(), UUID.randomUUID()))
+        expectMsg(OrderAdded)
 
-      engine ! Add(LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID(), UUID.randomUUID()))
-      engine ! Add(LimitOrder(BuyOrder, 200, 10.4, UUID.randomUUID(), UUID.randomUUID()))
-      engine ! Add(LimitOrder(BuyOrder, 50, 10.4, UUID.randomUUID(), UUID.randomUUID()))
-      engine ! Add(LimitOrder(BuyOrder, 30, 10.4, UUID.randomUUID(), UUID.randomUUID()))
+        engineActor ! Add(LimitOrder(SellOrder, 50, 11, UUID.randomUUID(), UUID.randomUUID()))
+        expectMsg(OrderAdded)
+        engineActor ! Add(LimitOrder(SellOrder, 50, 10.2, UUID.randomUUID(), UUID.randomUUID()))
+        expectMsg(OrderAdded)
+        engineActor ! Add(MarketOrder(SellOrder, 50, UUID.randomUUID(), UUID.randomUUID()))
+        expectMsg(OrderAdded)
 
-      engine ! Add(LimitOrder(SellOrder, 50, 11, UUID.randomUUID(), UUID.randomUUID()))
-      engine ! Add(LimitOrder(SellOrder, 50, 10.2, UUID.randomUUID(), UUID.randomUUID()))
-
-      Thread.sleep(1000)
-
-      engine ! Snapshot
+        engineActor ! Snapshot
+        expectMsgClass(MarketSnapshot(0, Nil, Nil, 0).getClass)
+      }
     }
+  }
+
+  override def afterAll() {
+    shutdown()
   }
 }

--- a/src/test/scala/darkpool/engine/MatchingEngineCancelOrdersSpec.scala
+++ b/src/test/scala/darkpool/engine/MatchingEngineCancelOrdersSpec.scala
@@ -1,0 +1,43 @@
+package darkpool.engine
+
+import java.util.UUID
+
+import darkpool.book.OrderBook
+import darkpool.models.orders.{BuyOrder, LimitOrder, SellOrder}
+import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+
+class MatchingEngineCancelOrdersSpec  extends FunSpec with Matchers with BeforeAndAfter {
+
+  describe("Canceling Orders from Matching Engine") {
+
+    var orderBookBuy = new OrderBook(BuyOrder)
+    var orderBookSell = new OrderBook(SellOrder)
+    var matchingEngine = new MatchingEngine(orderBookBuy, orderBookSell)
+
+    before {
+      // TODO: Add flush methods
+      orderBookBuy = new OrderBook(BuyOrder)
+      orderBookSell = new OrderBook(SellOrder)
+      matchingEngine = new MatchingEngine(orderBookBuy, orderBookSell)
+    }
+
+    it("will delete an order than has not been fulfilled") {
+      val buyOrder = LimitOrder(BuyOrder, 200, 10.5, UUID.randomUUID())
+      val sellOrder = LimitOrder(SellOrder, 200, 100.5, UUID.randomUUID())
+
+      matchingEngine.acceptOrder(buyOrder)
+      matchingEngine.acceptOrder(sellOrder)
+
+      orderBookBuy.top.get shouldEqual buyOrder
+      orderBookSell.top.get shouldEqual sellOrder
+
+      matchingEngine.cancelOrder(buyOrder)
+      matchingEngine.cancelOrder(sellOrder)
+
+      orderBookBuy.top shouldEqual None
+      orderBookSell.top shouldEqual None
+    }
+
+  }
+
+}

--- a/src/test/scala/darkpool/engine/MatchingEngineCancelOrdersSpec.scala
+++ b/src/test/scala/darkpool/engine/MatchingEngineCancelOrdersSpec.scala
@@ -6,7 +6,7 @@ import darkpool.book.OrderBook
 import darkpool.models.orders.{BuyOrder, LimitOrder, SellOrder}
 import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
 
-class MatchingEngineCancelOrdersSpec  extends FunSpec with Matchers with BeforeAndAfter {
+class MatchingEngineCancelOrdersSpec extends FunSpec with Matchers with BeforeAndAfter {
 
   describe("Canceling Orders from Matching Engine") {
 

--- a/src/test/scala/darkpool/engine/MatchingEngineCancelOrdersSpec.scala
+++ b/src/test/scala/darkpool/engine/MatchingEngineCancelOrdersSpec.scala
@@ -22,8 +22,8 @@ class MatchingEngineCancelOrdersSpec  extends FunSpec with Matchers with BeforeA
     }
 
     it("will delete an order than has not been fulfilled") {
-      val buyOrder = LimitOrder(BuyOrder, 200, 10.5, UUID.randomUUID())
-      val sellOrder = LimitOrder(SellOrder, 200, 100.5, UUID.randomUUID())
+      val buyOrder = LimitOrder(BuyOrder, 200, 10.5, UUID.randomUUID(), UUID.randomUUID())
+      val sellOrder = LimitOrder(SellOrder, 200, 100.5, UUID.randomUUID(), UUID.randomUUID())
 
       matchingEngine.acceptOrder(buyOrder)
       matchingEngine.acceptOrder(sellOrder)

--- a/src/test/scala/darkpool/engine/MatchingEngineLimitOrderSpec.scala
+++ b/src/test/scala/darkpool/engine/MatchingEngineLimitOrderSpec.scala
@@ -33,7 +33,7 @@ class MatchingEngineLimitOrderSpec extends FunSpec with Matchers with BeforeAndA
       val trade = matchingEngine.trades.head
       trade.price shouldBe 10.7
       trade.quantity shouldBe 100
-      trade.buyerId shouldBe buyOrder.id
+      trade.buyOrderId shouldBe buyOrder.id
     }
 
     it("can match trade price higher than top of book") {
@@ -43,7 +43,7 @@ class MatchingEngineLimitOrderSpec extends FunSpec with Matchers with BeforeAndA
       val trade = matchingEngine.trades.head
       trade.price shouldBe 10.7
       trade.quantity shouldBe 100
-      trade.buyerId shouldBe buyOrder.id
+      trade.buyOrderId shouldBe buyOrder.id
     }
 
     it("matches a Sell order large enough to clear the Buy book") {

--- a/src/test/scala/darkpool/engine/MatchingEngineLimitOrderSpec.scala
+++ b/src/test/scala/darkpool/engine/MatchingEngineLimitOrderSpec.scala
@@ -20,14 +20,14 @@ class MatchingEngineLimitOrderSpec extends FunSpec with Matchers with BeforeAndA
       orderBookSell = new OrderBook(SellOrder)
       matchingEngine = new MatchingEngine(orderBookBuy, orderBookSell)
 
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 200, 10.3, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.7, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 200, 10.8, UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 200, 10.3, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.7, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 200, 10.8, UUID.randomUUID(), UUID.randomUUID()))
     }
 
     it("can match identical buy order to outstanding sell order") {
-      val buyOrder = LimitOrder(BuyOrder, 100, 10.7, UUID.randomUUID())
+      val buyOrder = LimitOrder(BuyOrder, 100, 10.7, UUID.randomUUID(), UUID.randomUUID())
       matchingEngine.acceptOrder(buyOrder)
 
       val trade = matchingEngine.trades.head
@@ -37,7 +37,7 @@ class MatchingEngineLimitOrderSpec extends FunSpec with Matchers with BeforeAndA
     }
 
     it("can match trade price higher than top of book") {
-      val buyOrder = LimitOrder(BuyOrder, 100, 10.8, UUID.randomUUID())
+      val buyOrder = LimitOrder(BuyOrder, 100, 10.8, UUID.randomUUID(), UUID.randomUUID())
       matchingEngine.acceptOrder(buyOrder)
 
       val trade = matchingEngine.trades.head
@@ -47,7 +47,7 @@ class MatchingEngineLimitOrderSpec extends FunSpec with Matchers with BeforeAndA
     }
 
     it("matches a Sell order large enough to clear the Buy book") {
-      val limitOrder = LimitOrder(SellOrder, 350, 10.3, UUID.randomUUID())
+      val limitOrder = LimitOrder(SellOrder, 350, 10.3, UUID.randomUUID(), UUID.randomUUID())
       matchingEngine.acceptOrder(limitOrder)
 
       val trades = matchingEngine.trades
@@ -61,7 +61,7 @@ class MatchingEngineLimitOrderSpec extends FunSpec with Matchers with BeforeAndA
     }
 
     it("matches a large Buy order partially") {
-      val limitOrder = LimitOrder(BuyOrder, 350, 10.7, UUID.randomUUID())
+      val limitOrder = LimitOrder(BuyOrder, 350, 10.7, UUID.randomUUID(), UUID.randomUUID())
       matchingEngine.acceptOrder(limitOrder)
 
       val trade = matchingEngine.trades.head
@@ -74,7 +74,7 @@ class MatchingEngineLimitOrderSpec extends FunSpec with Matchers with BeforeAndA
     }
 
     it("matches a large sell order partially") {
-      val limitOrder = LimitOrder(SellOrder, 350, 10.4, UUID.randomUUID())
+      val limitOrder = LimitOrder(SellOrder, 350, 10.4, UUID.randomUUID(), UUID.randomUUID())
       matchingEngine.acceptOrder(limitOrder)
 
       val trade = matchingEngine.trades.head

--- a/src/test/scala/darkpool/engine/MatchingEngineLimitOrderSpec.scala
+++ b/src/test/scala/darkpool/engine/MatchingEngineLimitOrderSpec.scala
@@ -33,7 +33,7 @@ class MatchingEngineLimitOrderSpec extends FunSpec with Matchers with BeforeAndA
       val trade = matchingEngine.trades.head
       trade.price shouldBe 10.7
       trade.quantity shouldBe 100
-      trade.buyerUUID shouldBe buyOrder.id
+      trade.buyerId shouldBe buyOrder.id
     }
 
     it("can match trade price higher than top of book") {
@@ -43,7 +43,7 @@ class MatchingEngineLimitOrderSpec extends FunSpec with Matchers with BeforeAndA
       val trade = matchingEngine.trades.head
       trade.price shouldBe 10.7
       trade.quantity shouldBe 100
-      trade.buyerUUID shouldBe buyOrder.id
+      trade.buyerId shouldBe buyOrder.id
     }
 
     it("matches a Sell order large enough to clear the Buy book") {

--- a/src/test/scala/darkpool/engine/MatchingEngineMarketOrdersSpec.scala
+++ b/src/test/scala/darkpool/engine/MatchingEngineMarketOrdersSpec.scala
@@ -22,10 +22,10 @@ class MatchingEngineMarketOrdersSpec extends FunSpec with Matchers with BeforeAn
   describe("Incoming Market Order Scenarios") {
 
     it("matches a large Buy market order against multiple limit orders") {
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.7, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 200, 10.6, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 300, 10.5, UUID.randomUUID()))
-      matchingEngine.acceptOrder(MarketOrder(SellOrder, 650, UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.7, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 200, 10.6, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 300, 10.5, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(SellOrder, 650, UUID.randomUUID(), UUID.randomUUID()))
 
       val trades = matchingEngine.trades
       trades(0).price shouldBe 10.7
@@ -41,10 +41,10 @@ class MatchingEngineMarketOrdersSpec extends FunSpec with Matchers with BeforeAn
     }
 
     it("matches a small Buy market order against limit orders") {
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.7, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 200, 10.6, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 300, 10.5, UUID.randomUUID()))
-      matchingEngine.acceptOrder(MarketOrder(SellOrder, 150, UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.7, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 200, 10.6, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 300, 10.5, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(SellOrder, 150, UUID.randomUUID(), UUID.randomUUID()))
 
       val trades = matchingEngine.trades
       trades(0).price shouldBe 10.7
@@ -58,10 +58,10 @@ class MatchingEngineMarketOrdersSpec extends FunSpec with Matchers with BeforeAn
     }
 
     it("matches a large Sell market order against multiple limit orders") {
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 200, 10.6, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 300, 10.7, UUID.randomUUID()))
-      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 650, UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 200, 10.6, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 300, 10.7, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 650, UUID.randomUUID(), UUID.randomUUID()))
 
       val trades = matchingEngine.trades
       trades(0).price shouldBe 10.5
@@ -77,10 +77,10 @@ class MatchingEngineMarketOrdersSpec extends FunSpec with Matchers with BeforeAn
     }
 
     it("matches a small Sell market order against limit orders") {
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 200, 10.6, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 300, 10.7, UUID.randomUUID()))
-      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 150, UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 200, 10.6, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 300, 10.7, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 150, UUID.randomUUID(), UUID.randomUUID()))
 
       val trades = matchingEngine.trades
       trades(0).price shouldBe 10.5
@@ -96,8 +96,8 @@ class MatchingEngineMarketOrdersSpec extends FunSpec with Matchers with BeforeAn
 
   describe("Incoming Limit Orders to Outstanding Market Order Scenarios") {
     it("matches incoming Buy limit order against a single outstanding Sell market order") {
-      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 120, 10.5, UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 120, 10.5, UUID.randomUUID(), UUID.randomUUID()))
 
       val trade = matchingEngine.trades.head
       trade.price shouldBe 10.5
@@ -109,8 +109,8 @@ class MatchingEngineMarketOrdersSpec extends FunSpec with Matchers with BeforeAn
     }
 
     it("matches incoming Sell limit order against a single outstanding Buy market order") {
-      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 120, 10.5, UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 120, 10.5, UUID.randomUUID(), UUID.randomUUID()))
 
       val trade = matchingEngine.trades.head
       trade.price shouldBe 10.5
@@ -122,9 +122,9 @@ class MatchingEngineMarketOrdersSpec extends FunSpec with Matchers with BeforeAn
     }
 
     it("matches incoming Buy limit order against Sell market order while another NON-CROSSING Sell limit order is outstanding") {
-      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.6, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 120, 10.5, UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.6, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 120, 10.5, UUID.randomUUID(), UUID.randomUUID()))
 
       val trade = matchingEngine.trades.head
       trade.price shouldBe 10.5
@@ -136,9 +136,9 @@ class MatchingEngineMarketOrdersSpec extends FunSpec with Matchers with BeforeAn
     }
 
     it("matches incoming Sell limit order against Buy market order while another NON-CROSSING Buy limit order is outstanding") {
-      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 120, 10.5, UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.4, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 120, 10.5, UUID.randomUUID(), UUID.randomUUID()))
 
       val trade = matchingEngine.trades.head
       trade.price shouldBe 10.5
@@ -150,9 +150,9 @@ class MatchingEngineMarketOrdersSpec extends FunSpec with Matchers with BeforeAn
     }
 
     it("matches incoming Buy limit order against Sell market order while another CROSSING Sell limit order is outstanding") {
-      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.4, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 120, 10.5, UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.4, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 120, 10.5, UUID.randomUUID(), UUID.randomUUID()))
 
       val trades = matchingEngine.trades
       trades(0).price shouldBe 10.4
@@ -166,9 +166,9 @@ class MatchingEngineMarketOrdersSpec extends FunSpec with Matchers with BeforeAn
     }
 
     it("matches incoming Sell limit order against Buy market order while another CROSSING Buy limit order is outstanding") {
-      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.6, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 120, 10.5, UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.6, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 120, 10.5, UUID.randomUUID(), UUID.randomUUID()))
 
       val trades = matchingEngine.trades
       trades(0).price shouldBe 10.6
@@ -182,9 +182,9 @@ class MatchingEngineMarketOrdersSpec extends FunSpec with Matchers with BeforeAn
     }
 
     it("matches incoming Buy market order against Sell market order when another - limit - Sell order present") {
-      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID()))
-      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
 
       val trade = matchingEngine.trades.head
       trade.price shouldBe 10.5
@@ -196,9 +196,9 @@ class MatchingEngineMarketOrdersSpec extends FunSpec with Matchers with BeforeAn
     }
 
     it("matches incoming Sell market order against Buy market order when another - limit - Buy order present") {
-      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID()))
-      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
 
       val trade = matchingEngine.trades.head
       trade.price shouldBe 10.5
@@ -214,8 +214,8 @@ class MatchingEngineMarketOrdersSpec extends FunSpec with Matchers with BeforeAn
   describe("Matching Market Orders Using a Reference Price") {
 
     it("matches incoming Buy market order against Sell market order when no best limit price is available") {
-      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID()))
-      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
 
       val trade = matchingEngine.trades.head
       trade.price shouldBe 10
@@ -226,8 +226,8 @@ class MatchingEngineMarketOrdersSpec extends FunSpec with Matchers with BeforeAn
     }
 
     it("matches incoming Sell market order against Sell market order when no best limit price is available") {
-      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID()))
-      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
 
       val trade = matchingEngine.trades.head
       trade.price shouldBe 10

--- a/src/test/scala/darkpool/engine/MatchingEngineReferencePriceSpec.scala
+++ b/src/test/scala/darkpool/engine/MatchingEngineReferencePriceSpec.scala
@@ -18,20 +18,20 @@ class MatchingEngineReferencePriceSpec extends FunSpec with Matchers with Before
 
   describe("Updating Reference Price From Open") {
     it("maintains reference price as trades occur") {
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 11, UUID.randomUUID()))
-      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 11, UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 11, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 11, UUID.randomUUID(), UUID.randomUUID()))
 
       matchingEngine.trades.size shouldBe 1
       matchingEngine.referencePrice shouldBe 11
 
-      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 12, UUID.randomUUID()))
-      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 12, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
 
       matchingEngine.trades.size shouldBe 2
       matchingEngine.referencePrice shouldBe 12
 
-      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID()))
-      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(BuyOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(MarketOrder(SellOrder, 100, UUID.randomUUID(), UUID.randomUUID()))
 
       matchingEngine.trades.size shouldBe 3
       matchingEngine.referencePrice shouldBe 12

--- a/src/test/scala/darkpool/engine/MatchingEngineSelfMatchPreventionSpec.scala
+++ b/src/test/scala/darkpool/engine/MatchingEngineSelfMatchPreventionSpec.scala
@@ -1,0 +1,29 @@
+package darkpool.engine
+
+import darkpool.book.OrderBook
+import darkpool.models.orders.BuyOrder
+import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+
+class MatchingEngineSelfMatchPreventionSpec extends FunSpec with Matchers with BeforeAndAfter {
+
+  var orderBook = new OrderBook(BuyOrder)
+
+  before {
+    orderBook = new OrderBook(BuyOrder)
+  }
+
+  // We will use the Nasdaq self match prevention spec for tests: Version 1
+  // Source: https://www.nasdaqtrader.com/content/productsservices/trading/selfmatchprevention.pdf
+
+  describe("Self Trade Prevention") {
+
+    it("will remove orders that cancel out if share size is the same") {
+
+    }
+
+    it("will cancel the smaller order and adjust the larger order") {
+
+    }
+
+  }
+}

--- a/src/test/scala/darkpool/engine/MatchingEngineSelfMatchPreventionSpec.scala
+++ b/src/test/scala/darkpool/engine/MatchingEngineSelfMatchPreventionSpec.scala
@@ -1,15 +1,21 @@
 package darkpool.engine
 
+import java.util.UUID
+
 import darkpool.book.OrderBook
-import darkpool.models.orders.BuyOrder
+import darkpool.models.orders.{LimitOrder, SellOrder, BuyOrder}
 import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
 
 class MatchingEngineSelfMatchPreventionSpec extends FunSpec with Matchers with BeforeAndAfter {
 
-  var orderBook = new OrderBook(BuyOrder)
+  var orderBookBuy = new OrderBook(BuyOrder)
+  var orderBookSell = new OrderBook(SellOrder)
+  var matchingEngine = new MatchingEngine(orderBookBuy, orderBookSell)
 
   before {
-    orderBook = new OrderBook(BuyOrder)
+    orderBookBuy = new OrderBook(BuyOrder)
+    orderBookSell = new OrderBook(SellOrder)
+    matchingEngine = new MatchingEngine(orderBookBuy, orderBookSell)
   }
 
   // We will use the Nasdaq self match prevention spec for tests: Version 1
@@ -17,12 +23,46 @@ class MatchingEngineSelfMatchPreventionSpec extends FunSpec with Matchers with B
 
   describe("Self Trade Prevention") {
 
-    it("will remove orders that cancel out if share size is the same") {
+    it("will cancel the smaller order and adjust the larger order") {
+      val accountId = UUID.randomUUID()
 
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.6, UUID.randomUUID(), accountId))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 200, 10.5, UUID.randomUUID(), accountId))
+
+      matchingEngine.trades shouldBe Nil
+
+      // The buy order will dissolve
+      matchingEngine.books(BuyOrder)._1.orders shouldBe Nil
+
+      // The sell order will decrease by the buy order
+      matchingEngine.books(SellOrder)._1.orders.head.quantity shouldBe 100
     }
 
-    it("will cancel the smaller order and adjust the larger order") {
+    it("will remove orders that cancel out if share size is the same") {
+      val accountId = UUID.randomUUID()
 
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.6, UUID.randomUUID(), accountId))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID(), accountId))
+
+      matchingEngine.trades shouldBe Nil
+
+      // The buy order and sell order will dissolve
+      matchingEngine.books(BuyOrder)._1.orders shouldBe Nil
+      matchingEngine.books(SellOrder)._1.orders shouldBe Nil
+    }
+
+    it("will only check for self trade at execution time") {
+      val accountId = UUID.randomUUID()
+
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.5, UUID.randomUUID(), accountId))
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.6, UUID.randomUUID(), accountId))
+
+      matchingEngine.acceptOrder(LimitOrder(SellOrder, 100, 10.5, UUID.randomUUID(), UUID.randomUUID()))
+      matchingEngine.acceptOrder(LimitOrder(BuyOrder, 100, 10.6, UUID.randomUUID(), UUID.randomUUID()))
+
+      matchingEngine.trades.size shouldBe 2
+      matchingEngine.books(BuyOrder)._1.orders shouldBe Nil
+      matchingEngine.books(SellOrder)._1.orders shouldBe Nil
     }
 
   }

--- a/src/test/scala/darkpool/models/OrdersSpec.scala
+++ b/src/test/scala/darkpool/models/OrdersSpec.scala
@@ -10,7 +10,7 @@ class OrdersSpec extends FunSpec with Matchers {
   describe("LimitOrder") {
     it("can be created with correct params") {
       val randomUUID = UUID.randomUUID()
-      val limitOrder = LimitOrder(BuyOrder, 3.5, 300.00, randomUUID)
+      val limitOrder = LimitOrder(BuyOrder, 3.5, 300.00, randomUUID, randomUUID)
 
       limitOrder.createdAt should be > (DateTime.now - 1.second)
       limitOrder.id shouldBe randomUUID
@@ -19,7 +19,7 @@ class OrdersSpec extends FunSpec with Matchers {
     }
 
     it("extends an Buy trait") {
-      val limitOrder = LimitOrder(BuyOrder, 3.5, 300.00, UUID.randomUUID())
+      val limitOrder = LimitOrder(BuyOrder, 3.5, 300.00, UUID.randomUUID(), UUID.randomUUID())
       assert(limitOrder.orderType.isInstanceOf[Buy])
     }
   }
@@ -27,7 +27,7 @@ class OrdersSpec extends FunSpec with Matchers {
   describe("MarketOrder") {
     it("can be created with correct params") {
       val randomUUID = UUID.randomUUID()
-      val marketOrder = MarketOrder(SellOrder, 3.5, randomUUID)
+      val marketOrder = MarketOrder(SellOrder, 3.5, randomUUID, randomUUID)
 
       marketOrder.createdAt should be > (DateTime.now - 1.second)
       marketOrder.id shouldBe randomUUID
@@ -35,7 +35,7 @@ class OrdersSpec extends FunSpec with Matchers {
     }
 
     it("extends an Sell trait") {
-      val marketOrder = MarketOrder(SellOrder, 3.5, UUID.randomUUID())
+      val marketOrder = MarketOrder(SellOrder, 3.5, UUID.randomUUID(), UUID.randomUUID())
       assert(marketOrder.orderType.isInstanceOf[Sell])
     }
   }


### PR DESCRIPTION
This work in progress pull request is to implement the canceling of orders.

Example (engine part not yet done): 

``` scala
// 1) A places an order
val order = MarketOrder(BuyOrder, 200 /* quantity */, A)
matchingEngine.addOrder(order)
// 2) Let's say A waited 2 seconds and A saw this awful trade between A and B
//    => Trade(A, B, 1000.50, 100)
// 3) Now A has 100 quantity unfulfilled and wants to cancel because 1000.50 is too much
matchingEngine.cancelOrder(order)
// 4) Success! Now A's order has been canceled and A only bought 100 shares from B
```

This also adds the akka interface to the matching engine for remote calls:

``` scala
engineActor ! Add(LimitOrder(BuyOrder, 100, 10.4, 1, A)
// Receive => OrderAdded

engineActor ! Cancel(LimitOrder(BuyOrder, 100, 10.4, 1, A)
// Receive => OrderCanceled(LimitOrder(BuyOrder, 40, 10.4, 1, A)
// Meaning: The order was canceled partially. 60 units were already filled.

engineActor ! Snapshot
// Receive => MarketSnapshot(spread, buyBookVolume, sellBookVolume, referencePrice)
```
